### PR TITLE
feat(nuxt): support for isolated page injections

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -13,6 +13,7 @@
       :is="SingleRenderer"
       v-else-if="SingleRenderer"
     />
+    <NuxtPage v-if="route.meta.isolate" />
     <AppComponent v-else />
   </Suspense>
 </template>
@@ -42,6 +43,8 @@ if (import.meta.client && nuxtApp.isHydrating) {
 const url = import.meta.server ? nuxtApp.ssrContext.url : window.location.pathname
 const SingleRenderer = import.meta.test && import.meta.dev && import.meta.server && url.startsWith('/__nuxt_component_test__/') && defineAsyncComponent(() => import('#build/test-component-wrapper.mjs')
   .then(r => r.default(import.meta.server ? url : window.location.href)))
+
+const route = useRoute()
 
 // Inject default route (outside of pages) as active route
 provide(PageRouteSymbol, useRoute())

--- a/playground/modules/test_module/index.ts
+++ b/playground/modules/test_module/index.ts
@@ -1,0 +1,23 @@
+// `nuxt/kit` is a helper subpath import you can use when defining local modules
+// that means you do not need to add `@nuxt/kit` to your project's dependencies
+import { createResolver, defineNuxtModule, extendPages } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'test-module',
+  },
+  setup (options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+
+    extendPages((pages) => {
+      pages.unshift({
+        name: 'isolated',
+        path: '/isolate',
+        file: resolve('./runtime/isolate.vue'),
+        meta: {
+          isolate: true,
+        },
+      })
+    })
+  },
+})

--- a/playground/modules/test_module/runtime/isolate.vue
+++ b/playground/modules/test_module/runtime/isolate.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello isolate
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Updates `nuxt-root.vue` to render pages with `meta.isolate` outside of
the user's app.vue. This allows module authors to inject pages without
inheriting from user's code.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
